### PR TITLE
Remove legacy includes

### DIFF
--- a/src/KeyRingCallbacks.h
+++ b/src/KeyRingCallbacks.h
@@ -15,9 +15,9 @@
 
 #include <iostream>
 
-#include <zypp/base/Logger.h>
+#include <zypp-core/base/Logger.h>
 #include <zypp/ZYppCallbacks.h>
-#include <zypp/Pathname.h>
+#include <zypp-core/Pathname.h>
 #include <zypp/KeyRing.h>
 #include <zypp/Digest.h>
 

--- a/src/deptestomatic.cc
+++ b/src/deptestomatic.cc
@@ -51,11 +51,11 @@
 #include "zypp/Locale.h"
 #include "zypp/ZConfig.h"
 
-#include "zypp/base/String.h"
-#include "zypp/base/StringV.h"
-#include "zypp/base/LogTools.h"
-#include "zypp/base/LogControl.h"
-#include "zypp/base/Exception.h"
+#include <zypp-core/base/String.h>
+#include <zypp-core/base/StringV.h>
+#include <zypp-core/base/LogTools.h>
+#include <zypp-core/base/LogControl.h>
+#include <zypp-core/base/Exception.h>
 #include "zypp/base/Algorithm.h"
 #include "zypp/base/SetTracker.h"
 


### PR DESCRIPTION
Fixes required to build in zypp-stack for the new libzypp project structure